### PR TITLE
fix msvc build

### DIFF
--- a/sqlite-vec.c
+++ b/sqlite-vec.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <float.h>
 
 #include "sqlite3ext.h"
 SQLITE_EXTENSION_INIT1
@@ -296,6 +297,12 @@ static f32 distance_hamming_u8(u8 *a, u8 *b, size_t n) {
   }
   return (f32)same;
 }
+
+#ifdef _MSC_VER
+#  include <intrin.h>
+#  define __builtin_popcountl __popcnt64
+#endif
+
 static f32 distance_hamming_u64(u64 *a, u64 *b, size_t n) {
   int same = 0;
   for (unsigned long i = 0; i < n; i++) {
@@ -384,7 +391,7 @@ int array_append(struct Array *array, const void *element) {
       return SQLITE_NOMEM;
     }
   }
-  memcpy(&array->z[array->length * array->element_size], element,
+  memcpy((char *)(&array->z)[array->length * array->element_size], element,
          array->element_size);
   array->length++;
   return SQLITE_OK;
@@ -2368,7 +2375,7 @@ static int vec_npy_eachColumn(sqlite3_vtab_cursor *cur,
       case SQLITE_VEC_ELEMENT_TYPE_FLOAT32: {
         sqlite3_result_blob(
             context,
-            &pCur->vector[pCur->iRowid * pCur->nDimensions * sizeof(f32)],
+            (f32 *)(&pCur->vector)[pCur->iRowid * pCur->nDimensions * sizeof(f32)],
             pCur->nDimensions * sizeof(f32), SQLITE_STATIC);
         break;
       }
@@ -2382,7 +2389,7 @@ static int vec_npy_eachColumn(sqlite3_vtab_cursor *cur,
       switch (pCur->elementType) {
       case SQLITE_VEC_ELEMENT_TYPE_FLOAT32: {
         sqlite3_result_blob(context,
-                            &pCur->fileBuffer[pCur->bufferIndex *
+                            (f32 *)(&pCur->fileBuffer)[pCur->bufferIndex *
                                               pCur->nDimensions * sizeof(f32)],
                             pCur->nDimensions * sizeof(f32), SQLITE_TRANSIENT);
         break;
@@ -3536,7 +3543,7 @@ int vec0Filter_knn(vec0_cursor *pCur, vec0_vtab *p, int idxNum,
   f32 *topk_distances = sqlite3_malloc(k * sizeof(f32));
   todo_assert(topk_distances);
   for (int i = 0; i < k; i++) {
-    topk_distances[i] = __FLT_MAX__;
+    topk_distances[i] = FLT_MAX;
   }
 
   // for each chunk, get top min(k, chunk_size) rowid + distances to query vec.
@@ -3604,7 +3611,7 @@ int vec0Filter_knn(vec0_cursor *pCur, vec0_vtab *p, int idxNum,
         // Ensure the current vector is "valid" in the validity bitmap.
         // If not, skip and continue on
         if (!(((chunkValidity[i / CHAR_BIT]) >> (i % CHAR_BIT)) & 1)) {
-          chunk_distances[i] = __FLT_MAX__;
+          chunk_distances[i] = FLT_MAX;
           continue;
         };
         // If pre-filtering, make sure the rowid appears in the `rowid in (...)`
@@ -3614,7 +3621,7 @@ int vec0Filter_knn(vec0_cursor *pCur, vec0_vtab *p, int idxNum,
           void *in = bsearch(&rowid, arrayRowidsIn->z, arrayRowidsIn->length,
                              sizeof(i64), _cmp);
           if (!in) {
-            chunk_distances[i] = __FLT_MAX__;
+            chunk_distances[i] = FLT_MAX;
             continue;
           }
         }
@@ -3846,7 +3853,7 @@ static int vec0Eof(sqlite3_vtab_cursor *cur) {
     todo_assert(pCur->knn_data);
     return (pCur->knn_data->current_idx >= pCur->knn_data->k) ||
            (pCur->knn_data->distances[pCur->knn_data->current_idx] ==
-            __FLT_MAX__);
+            FLT_MAX);
   }
   case SQLITE_VEC0_QUERYPLAN_POINT: {
     todo_assert(pCur->point_data);
@@ -5250,7 +5257,7 @@ static int vec_expoFilter(sqlite3_vtab_cursor *pVtabCursor, int idxNum,
     f32 *chunk_distances = sqlite3_malloc(chunk_size * sizeof(f32));
     todo_assert(chunk_distances);
     for (int i = 0; i < k; i++) {
-      topk_distances[i] = __FLT_MAX__;
+      topk_distances[i] = FLT_MAX;
     }
     i64 *chunk_rowids = sqlite3_malloc(chunk_size * sizeof(i64));
     todo_assert(chunk_rowids);
@@ -5532,9 +5539,6 @@ __declspec(dllexport)
 #define SQLITE_RESULT_SUBTYPE 0x001000000
 #endif
 
-#ifdef _WIN32
-__declspec(dllexport)
-#endif
     int sqlite3_vec_init(sqlite3 *db, char **pzErrMsg,
                          const sqlite3_api_routines *pApi) {
   SQLITE_EXTENSION_INIT2(pApi);
@@ -5542,7 +5546,7 @@ __declspec(dllexport)
   const int DEFAULT_FLAGS =
       SQLITE_UTF8 | SQLITE_INNOCUOUS | SQLITE_DETERMINISTIC;
 
-  static const struct {
+  const struct {
     char *zFName;
     void (*xFunc)(sqlite3_context *, int, sqlite3_value **);
     int nArg;
@@ -5625,9 +5629,6 @@ __declspec(dllexport)
   return SQLITE_OK;
 }
 
-#ifdef _WIN32
-__declspec(dllexport)
-#endif
     int sqlite3_vec_fs_read_init(sqlite3 *db, char **pzErrMsg,
                                  const sqlite3_api_routines *pApi) {
   UNUSED_PARAMETER(pzErrMsg);

--- a/sqlite-vec.h.tmpl
+++ b/sqlite-vec.h.tmpl
@@ -11,8 +11,15 @@
 extern "C" {
 #endif
 
+#ifdef _WIN32
+__declspec(dllexport)
+#endif
 int sqlite3_vec_init(sqlite3 *db, char **pzErrMsg,
                   const sqlite3_api_routines *pApi);
+
+#ifdef _WIN32
+__declspec(dllexport)
+#endif
 int sqlite3_vec_fs_read_init(sqlite3 *db, char **pzErrMsg,
                           const sqlite3_api_routines *pApi);
 


### PR DESCRIPTION
An attempt to fix https://github.com/asg017/sqlite-vec/issues/13

I am not super familiar with c memory stuff, please check if the casts are correct.

And I simply cannot get `static const struct` to work with function pointer in MSVC, is there a big difference to be `static` or not?

This works: `cl.exe sqlite-vec.c /std:clatest /MT /link /DLL /OUT:sqlite-vec.dll`