### PR TITLE
int8 vec from text

### DIFF
--- a/tests/test-loadable.py
+++ b/tests/test-loadable.py
@@ -211,6 +211,8 @@ def test_vec_int8():
     vec_int8 = lambda *args: db.execute("select vec_int8(?)", args).fetchone()[0]
     assert vec_int8(b"\x00") == _int8([0])
     assert vec_int8(b"\x00\x0f") == _int8([0, 15])
+    assert vec_int8("[0]") == _int8([0])
+    assert vec_int8("[1, 2, 3]") == _int8([1, 2, 3])
 
     if SUPPORTS_SUBTYPE:
         assert db.execute("select subtype(vec_int8(?))", [b"\x00"]).fetchone()[0] == 225


### PR DESCRIPTION
This is a small PR to add support for declaring int8 vectors with JSON formatted text. The logic is almost identical to the float32 logic. The only notable difference is a bound check. Since we are converting the string to a long before int8 we must check that the long is within the bounds of int8. 