### PR TITLE
L2 int8 neon implementation

### DIFF
--- a/sqlite-vec.c
+++ b/sqlite-vec.c
@@ -189,7 +189,6 @@ static f32 l2_sqr_float_neon(const void *pVect1v, const void *pVect2v,
       vaddvq_f32(vaddq_f32(vaddq_f32(sum0, sum1), vaddq_f32(sum2, sum3))));
 }
 
-// TODO: test this!!!
 static f32 l2_sqr_int8_neon(const void *pVect1v, const void *pVect2v,
                             const void *qty_ptr) {
   i8 *pVect1 = (i8 *)pVect1v;

--- a/sqlite-vec.c
+++ b/sqlite-vec.c
@@ -64,6 +64,7 @@ typedef u_int64_t uint64_t;
 
 typedef int8_t i8;
 typedef uint8_t u8;
+typedef int16_t i16;
 typedef int32_t i32;
 typedef sqlite3_int64 i64;
 typedef uint32_t u32;
@@ -187,6 +188,46 @@ static f32 l2_sqr_float_neon(const void *pVect1v, const void *pVect2v,
   return sqrt(
       vaddvq_f32(vaddq_f32(vaddq_f32(sum0, sum1), vaddq_f32(sum2, sum3))));
 }
+
+// TODO: test this!!!
+static f32 l2_sqr_int8_neon(const void *pVect1v, const void *pVect2v,
+                            const void *qty_ptr) {
+  i8 *pVect1 = (i8 *)pVect1v;
+  i8 *pVect2 = (i8 *)pVect2v;
+  size_t qty = *((size_t *)qty_ptr);
+
+  const i8 *pEnd1 = pVect1 + qty;
+  i32 sum_scalar = 0;
+
+  while (pVect1 < pEnd1 - 7) {
+    // loading 8 at a time
+    int8x8_t v1 = vld1_s8(pVect1);
+    int8x8_t v2 = vld1_s8(pVect2);
+    pVect1 += 8;
+    pVect2 += 8;
+
+    // widen to protect against overflow
+    int16x8_t v1_wide = vmovl_s8(v1);
+    int16x8_t v2_wide = vmovl_s8(v2);
+
+    int16x8_t diff = vsubq_s16(v1_wide, v2_wide);
+    int16x8_t squared_diff = vmulq_s16(diff, diff);
+    int32x4_t sum = vpaddlq_s16(squared_diff);
+
+    sum_scalar += vgetq_lane_s32(sum, 0) + vgetq_lane_s32(sum, 1) +
+              vgetq_lane_s32(sum, 2) + vgetq_lane_s32(sum, 3);
+  }
+
+  // handle leftovers
+  while (pVect1 < pEnd1) {
+    i16 diff = (i16)*pVect1 - (i16)*pVect2;
+    sum_scalar += diff * diff;
+    pVect1++;
+    pVect2++;
+  }
+
+  return sqrtf(sum_scalar);
+}
 #endif
 
 static f32 l2_sqr_float(const void *pVect1v, const void *pVect2v,
@@ -235,6 +276,11 @@ static f32 distance_l2_sqr_float(const void *a, const void *b, const void *d) {
 }
 
 static f32 distance_l2_sqr_int8(const void *a, const void *b, const void *d) {
+  #ifdef SQLITE_VEC_ENABLE_NEON
+  if ((*(const size_t *)d) > 7) {
+    return l2_sqr_int8_neon(a, b, d);
+  }
+  #endif
   return l2_sqr_int8(a, b, d);
 }
 


### PR DESCRIPTION
## L2 int8 neon implementation
This PR contains a neon implementation of L2 distance for int8. I was not exactly sure how to test this effectively given that it is dependent on architecture. So, below I will detail how I tested this work locally on my 8-core M1 Pro.

### Correctness
The first thing to confirm is whether results are consistent with the existing sequential method. I used the following script for this (note: this depends on my other PR adding json input support for int8 vectors):
```sql
.bail on
.mode box
.header on

.load ./dist/vec0
create virtual table vectors using vec0(
  vec int[9]
);
insert into vectors(rowid, vec)
  values
    (1, vec_int8('[1, 2, 3, 4, 5, 6, 7, 8, 1]')),
    (2, vec_int8('[1, 20, 38, 23, 29, 4, 10, 9, 3]'));

.timer on
SELECT v1.rowid as id1, v2.rowid as id2, vec_distance_l2(v1.vec, v2.vec) as l2_distance
FROM vectors v1
CROSS JOIN vectors v2
WHERE v1.rowid = 1 AND v2.rowid != 1;
.timer off
```
Without the neon implementation: 
```
┌─────┬─────┬──────────────────┐
│ id1 │ id2 │   l2_distance    │
├─────┼─────┼──────────────────┤
│ 1   │ 2   │ 50.0399856567383 │
└─────┴─────┴──────────────────┘
```
With the neon implementation: 
```
┌─────┬─────┬──────────────────┐
│ id1 │ id2 │   l2_distance    │
├─────┼─────┼──────────────────┤
│ 1   │ 2   │ 50.0399856567383 │
└─────┴─────┴──────────────────┘
```
 
### Is it worth it?
To test whether this improvement is worthwhile, I wrote a script that initializes ~1000 rows with vectors of size 2003 and then calculates their L2 distances from one another. It uses the `timeit` library to get a general idea of how long it takes to execute. There are likely more rigorous ways to benchmark this functionality, but this does a good enough job at showing the performance gain in my opinion. 
<details>
<summary>Script</summary>

```python
import sqlite3
import random
import json
import timeit

def create_table_and_insert_data(conn, vector_size, num_rows, seed=42):
    conn.execute(f"CREATE VIRTUAL TABLE IF NOT EXISTS vectors USING vec0(vec int[{vector_size}])")
    
    random.seed(seed)
    data = []
    for i in range(num_rows):
        vector = [random.randint(1, 100) for _ in range(vector_size)]
        data.append((i+1, json.dumps(vector) ))
        
    conn.executemany("INSERT INTO vectors(rowid, vec) VALUES (?, vec_int8(?))", data)

def calculate_distances(conn):
    cursor = conn.cursor()
    cursor.execute('''
        SELECT v1.rowid as id1, v2.rowid as id2, vec_distance_l2(v1.vec, v2.vec) as l2_distance
        FROM vectors v1
        CROSS JOIN vectors v2
        WHERE v1.rowid = 1 AND v2.rowid != 1
    ''')
    results = cursor.fetchall()

def main():
    vector_size = 2003
    num_rows = 1005
    seed = 42
    
    conn = sqlite3.connect(':memory:')
    conn.enable_load_extension(True)
    conn.load_extension('./dist/vec0')
    
    create_table_and_insert_data(conn, vector_size, num_rows, seed)
    
    def run_query():
        calculate_distances(conn)
    
    execution_time = timeit.timeit(run_query, number=100)
    print(f"Total execution time over 100 runs: {execution_time:.5f} seconds")
    
    conn.close()

if __name__ == '__main__':
    main()
```
</details>

Without the neon implementation: 
```
Total execution time over 100 runs: 0.29578 seconds
```
With the neon implementation:
```
Total execution time over 100 runs: 0.12515 seconds
```
That is a pretty nice speed up for folks running on Arm hardware!