### PR TITLE
Update go docs

### DIFF
--- a/site/using/go.md
+++ b/site/using/go.md
@@ -107,7 +107,10 @@ If vectors are provided as a list of floats, use `SerializeFloat32(list)` to ser
 values := []float32{0.1, 0.1, 0.1, 0.1}
 v, err := sqlite_vec.SerializeFloat32(values)
 if err != nil {
-  log.Fatal(err)
+	log.Fatal(err)
 }
-stmt.BindInt(1, id)
+_, err = db.Exec("INSERT INTO vec_items(rowid, embedding) VALUES (?, ?)", id, v)
+if err != nil {
+	log.Fatal(err)
+}
 ```


### PR DESCRIPTION
I'm guessing this version (from the CGO example) is more widely applicable (I ship a `database/sql` driver as well).

PS: if you find that all the copies and allocs are a bottleneck, I'm guessing an `buf, err := sqlite_vec .AppendFloat32(buf, values)`, or even an API change (on my side) that allows serializing directly into "native" memory, would help.