### PR TITLE
Avoid `__popcnt64` on MSVC Windows 32-bit platform

### DIFF
--- a/sqlite-vec.c
+++ b/sqlite-vec.c
@@ -782,7 +782,11 @@ static unsigned int __builtin_popcountl(unsigned int x) {
 }
 #else
 #include <intrin.h>
+#ifdef _WIN64
 #define __builtin_popcountl __popcnt64
+#else
+static unsigned int __builtin_popcountl(u64 n) { return __popcnt((u32)n) + __popcnt((u32)(n >> 32)); }
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
The `__popcnt64` intrinsic isn't supported on 32-bit Windows, so `__popcnt` should be used instead.

See also https://learn.microsoft.com/en-us/cpp/intrinsics/popcnt16-popcnt-popcnt64?view=msvc-170.

----
IMO, ideally we should use `stdc_count_ones` (see [here](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3022.htm#design-bit-count_ones.count_zeros) and [WG14 N3220](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3220.pdf)). But it will take a long long while until C23 will become popular enough.