### PR TITLE
The  sqlite-vec-linux-arm64.tar.gz was not published on npm.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -278,6 +278,7 @@ jobs:
           npm publish --access public distx/npm/sqlite-vec-darwin-arm64.tar.gz
           npm publish --access public distx/npm/sqlite-vec-darwin-x64.tar.gz
           npm publish --access public distx/npm/sqlite-vec-linux-x64.tar.gz
+          npm publish --access public distx/npm/sqlite-vec-linux-arm64.tar.gz
           npm publish --access public distx/npm/sqlite-vec-windows-x64.tar.gz
           npm publish --access public distx/npm/sqlite-vec-wasm-demo.tar.gz
           npm publish --access public distx/npm/sqlite-vec.tar.gz


### PR DESCRIPTION
uname: arm64
deno version: deno 2.1.2
exec
```sh
deno add npm:sqlite-vec
```
error
<img width="517" alt="スクリーンショット 2024-11-30 14 46 42" src="https://github.com/user-attachments/assets/5b49e005-0298-4ed6-add2-91fbb6e0ae03">

# Reproduction steps

```sh
npm pack sqlite-vec  
# get sqlite-vec-0.1.6.tgz
```
unpack
```sh
mkdir sqlite-vec-content
tar -xzf sqlite-vec-0.1.6.tgz -C sqlite-vec-content
cd sqlite-vec-content
```
The package sqlite-vec-linux-arm64 is added as a dependency, but there is no npm publish for it.                              

cat package.json
```
{
  "name": "sqlite-vec",
  "version": "0.1.6",
  "author": "Alex Garcia",
  "license": "MIT OR Apache",
  "description": "A vector search SQLite extension.",
  "repository": {
    "type": "git",
    "url": "https://TODO",
    "directory": null
  },
  "main": "./index.cjs",
  "module": "./index.mjs",
  "types": "./index.d.ts",
  "exports": {
    ".": {
      "require": "./index.cjs",
      "import": "./index.mjs",
      "types": "./index.d.ts"
    }
  },
  "files": [],
  "keywords": [],
  "optionalDependencies": {
    "sqlite-vec-linux-arm64": "0.1.6",
    "sqlite-vec-windows-x64": "0.1.6",
    "sqlite-vec-darwin-x64": "0.1.6",
    "sqlite-vec-linux-x64": "0.1.6",
    "sqlite-vec-darwin-arm64": "0.1.6"
  }
}


```
