### PR TITLE
Document reading a vector form sqlite to python

### DIFF
--- a/site/using/python.md
+++ b/site/using/python.md
@@ -67,6 +67,20 @@ db.execute(
 ) # 4
 ```
 
+### Reading Vectors
+
+When reading vectors from a SQLite database, you can use the `vec_to_json()` function to convert the BLOB format into a JSON array.
+
+```python
+import json
+
+db.execute("CREATE TABLE test (embedding BLOB)")
+db.execute("INSERT INTO test VALUES (?)", [serialize_float32([0.1, 0.2, 0.3, 0.4])])
+
+json_str, = db.execute("SELECT vec_to_json(embedding) FROM test").fetchone()
+print(json.loads(json_str)) # [0.1, 0.2, 0.3, 0.4]
+```
+
 
 ## Using an up-to-date version of SQLite {#updated-sqlite}
 


### PR DESCRIPTION
I was missing an example on the documentation on how to read an embedding vector from my SQLite database to a python variable. From the discord channel I saw someone using vec_to_json for this, so I added this to the docs.

I wonder if there is a better method.

Thanks!
