### PR TITLE
Fix build for linux-aarch64 and clean up Android dupes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,10 +58,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: sudo apt-get install gcc-arm-linux-gnueabihf
+      - run: sudo apt-get install gcc-aarch64-linux-gnu
       - run: ./scripts/vendor.sh
       - run: make sqlite-vec.h
-      - run: make CC=arm-linux-gnueabihf-gcc loadable static
+      - run: make CC=aarch64-linux-gnu-gcc loadable static
       - uses: actions/upload-artifact@v4
         with:
           name: sqlite-vec-linux-aarch64-extension
@@ -233,10 +233,6 @@ jobs:
         with:
           name: sqlite-vec-android-x86_64-extension
           path: dist/android-x86_64
-      - uses: actions/download-artifact@v4
-        with:
-          name: sqlite-vec-android-armv7a-extension
-          path: dist/android-armv7a
       - uses: actions/download-artifact@v4
         with:
           name: sqlite-vec-android-armv7a-extension


### PR DESCRIPTION
- Switched to the correct compiler (gcc-aarch64-linux-gnu) for linux-aarch64 builds to ensure 64-bit binaries are generated.
- Removed duplicate artifact upload for sqlite-vec-android-armv7a-extension in the dist job.

Resolves: #159