### PR TITLE
WIP: Support constaints on `distance` column in KNN queries, for pagination and range queries

### DIFF
--- a/dbg.sql
+++ b/dbg.sql
@@ -1,0 +1,21 @@
+.load dist/vec0
+
+
+create virtual table vec_items using vec0(
+  vector float[1]
+);
+
+insert into vec_items(rowid, vector)
+  select value, json_array(value) from generate_series(1, 100);
+
+
+select vec_to_json(vector), distance
+from vec_items
+where vector match '[1]'
+  and k = 5;
+
+select vec_to_json(vector), distance
+from vec_items
+where vector match '[1]'
+  and k = 5
+  and distance > 4.0;


### PR DESCRIPTION
refs #165 

```sql
.load dist/vec0
create virtual table vec_items using vec0(
  vector float[1]
);

insert into vec_items(rowid, vector)
  select value, json_array(value) from generate_series(1, 100);

select vec_to_json(vector), distance
from vec_items
where vector match '[1]'
  and k = 5;

/*
┌─────────────────────┬──────────┐
│ vec_to_json(vector) │ distance │
├─────────────────────┼──────────┤
│ '[1.000000]'        │ 0.0      │
│ '[2.000000]'        │ 1.0      │
│ '[3.000000]'        │ 2.0      │
│ '[4.000000]'        │ 3.0      │
│ '[5.000000]'        │ 4.0      │
└─────────────────────┴──────────┘
*/


select vec_to_json(vector), distance
from vec_items
where vector match '[1]'
  and k = 5
  -- the new magic
  and distance > 4.0;

/*
┌─────────────────────┬──────────┐
│ vec_to_json(vector) │ distance │
├─────────────────────┼──────────┤
│ '[6.000000]'        │ 5.0      │
│ '[7.000000]'        │ 6.0      │
│ '[8.000000]'        │ 7.0      │
│ '[9.000000]'        │ 8.0      │
│ '[10.000000]'       │ 9.0      │
└─────────────────────┴──────────┘
*/
```

## TODO

- [ ] tests
- [ ] docs
- [ ] edge cases - when multiple items have same distance calculations
- [ ] should distances be f64?