### PR TITLE
include the directory of the downloaded sqlit version...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,8 +257,8 @@ $(SQLITE_WASM_COMPILED_SQLITE3C): $(SQLITE_WASM_SRCZIP) $(BUILD_DIR)
 	touch $@
 
 $(TARGET_WASM_LIB): examples/wasm/wasm.c sqlite-vec.c $(BUILD_DIR) $(WASM_DIR)
-	emcc -O3  -I./ -Ivendor -DSQLITE_CORE -c examples/wasm/wasm.c -o $(BUILD_DIR)/wasm.wasm.o
-	emcc -O3  -I./ -Ivendor -DSQLITE_CORE -c sqlite-vec.c -o $(BUILD_DIR)/sqlite-vec.wasm.o
+	emcc -O3 -I./ -Ivendor -I$(BUILD_DIR)/sqlite-src-$(SQLITE_WASM_VERSION) -DSQLITE_CORE -c examples/wasm/wasm.c -o $(BUILD_DIR)/wasm.wasm.o
+	emcc -O3 -I./ -Ivendor -I$(BUILD_DIR)/sqlite-src-$(SQLITE_WASM_VERSION) -DSQLITE_CORE -c sqlite-vec.c -o $(BUILD_DIR)/sqlite-vec.wasm.o
 	emar rcs $@ $(BUILD_DIR)/wasm.wasm.o $(BUILD_DIR)/sqlite-vec.wasm.o
 
 $(SQLITE_WASM_COMPILED_MJS) $(SQLITE_WASM_COMPILED_WASM): $(SQLITE_WASM_COMPILED_SQLITE3C) $(TARGET_WASM_LIB)


### PR DESCRIPTION
It might be better to include the correct header files from the downloaded sqlite version instead of relying on the system-installed versions for WASM builds. 