### PR TITLE
Fix for musl compile

### DIFF
--- a/scripts/vendor.sh
+++ b/scripts/vendor.sh
@@ -1,7 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 mkdir -p vendor
 curl -o sqlite-amalgamation.zip https://www.sqlite.org/2024/sqlite-amalgamation-3450300.zip
-unzip -d
 unzip sqlite-amalgamation.zip
 mv sqlite-amalgamation-3450300/* vendor/
 rmdir sqlite-amalgamation-3450300

--- a/sqlite-vec.c
+++ b/sqlite-vec.c
@@ -61,16 +61,10 @@ SQLITE_EXTENSION_INIT1
 #define LONGDOUBLE_TYPE long double
 #endif
 
-#ifndef _WIN32
-#ifndef __EMSCRIPTEN__
-#ifndef __COSMOPOLITAN__
-#ifndef __wasi__
+#ifndef UINT8_MAX
 typedef u_int8_t uint8_t;
 typedef u_int16_t uint16_t;
 typedef u_int64_t uint64_t;
-#endif
-#endif
-#endif
 #endif
 
 typedef int8_t i8;


### PR DESCRIPTION
This failed while compiling in Alpine in docker.
Type redefinitions.
Figured this might be a better way to conditionally check for the presence of a compliant C library (but I might be wrong).
Also made some small changes to `scripts/vendor.sh` since my bash isn't in that location and to my understanding this is the expected way to use the user's bash, and I got an error on the `unzip -d` line and as far as I'm concerned that didn't do anything meaningful, but that might just be an indication of a different bug. For example you might have meant to do `unzip sqlite-amalgamation.zip -d sqlite-amalgamation-3450300` or something like that, I honestly didn't bother with it too much.
Obviously feel free to correct the changes or close the pull request.