### PR TITLE
Remove unnecessary redefinitions of uint*_t types

### DIFF
--- a/sqlite-vec.c
+++ b/sqlite-vec.c
@@ -61,18 +61,6 @@ SQLITE_EXTENSION_INIT1
 #define LONGDOUBLE_TYPE long double
 #endif
 
-#ifndef _WIN32
-#ifndef __EMSCRIPTEN__
-#ifndef __COSMOPOLITAN__
-#ifndef __wasi__
-typedef u_int8_t uint8_t;
-typedef u_int16_t uint16_t;
-typedef u_int64_t uint64_t;
-#endif
-#endif
-#endif
-#endif
-
 typedef int8_t i8;
 typedef uint8_t u8;
 typedef int16_t i16;


### PR DESCRIPTION
while the spec (ISO 9899:1999, 7.18.1.1) makes these typedefs optional, in practice they are defined in <stdint.h> for all supported platforms

types u_int*_t are BSDisms and might not exist, making the typedefs fail with `error: unknown type name ‘u_int8_t’`, e.g. on Solaris or musl libc