### PR TITLE
Use definitions from stdint.h instead define uintXX_t by hand

### DIFF
--- a/sqlite-vec.c
+++ b/sqlite-vec.c
@@ -61,18 +61,6 @@ SQLITE_EXTENSION_INIT1
 #define LONGDOUBLE_TYPE long double
 #endif
 
-#ifndef _WIN32
-#ifndef __EMSCRIPTEN__
-#ifndef __COSMOPOLITAN__
-#ifndef __wasi__
-typedef u_int8_t uint8_t;
-typedef u_int16_t uint16_t;
-typedef u_int64_t uint64_t;
-#endif
-#endif
-#endif
-#endif
-
 typedef int8_t i8;
 typedef uint8_t u8;
 typedef int16_t i16;


### PR DESCRIPTION
```
    These hand-written definitions don't compile on some platforms like
    musl since u_intXX_t (with two underscores) types aren't standard. As
    stdint.h already contains defintions for uintXX_t types, there's no
    reason to define them manually. Let's clean them up.
```