### PR TITLE
Fix linux x86 build and use native arm64 runner instead of cross compile

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ permissions:
   contents: read
 jobs:
   build-linux-x86_64-extension:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - run: ./scripts/vendor.sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,13 +55,12 @@ jobs:
           name: sqlite-vec-windows-x86_64-extension
           path: dist/*
   build-linux-aarch64-extension:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
-      - run: sudo apt-get install gcc-aarch64-linux-gnu
       - run: ./scripts/vendor.sh
       - run: make sqlite-vec.h
-      - run: make CC=aarch64-linux-gnu-gcc loadable static
+      - run: make loadable static
       - uses: actions/upload-artifact@v4
         with:
           name: sqlite-vec-linux-aarch64-extension


### PR DESCRIPTION
While debugging #211 I randomly noticed that the arm64 build could be improved by using GitHub's recent native arm runners - while cross compiling is probably ok too, I think it can be safer to use a native builder.

Also when testing it, I noticed the x86 build can't work anymore since it's using a deprecated runner.

https://github.com/anuraaga/sqlite-vec/actions/runs/15769789007/job/44452544135

```
❯ file vec0.so
vec0.so: ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV), dynamically linked, BuildID[sha1]=fb446ba691d9e8cd31e173928a061fbc46a80979, not stripped
```