### PR TITLE
Update docs and demo in "Using sqlite-vec in Rust"

### DIFF
--- a/examples/simple-rust/Cargo.toml
+++ b/examples/simple-rust/Cargo.toml
@@ -3,10 +3,10 @@ name = "sqlite-vec-demo"
 edition = "2021"
 
 [dependencies]
-sqlite-vec={version="0.0.1-alpha.7"}
-rusqlite = {version="0.31.0", features=["bundled"]}
-zerocopy = "0.7.33"
+sqlite-vec = "0.1.6"
+rusqlite = { version = "0.37.0", features = ["bundled"] }
+zerocopy = "0.8.27"
 
 [[bin]]
-name="demo"
-path="demo.rs"
+name = "demo"
+path = "demo.rs"

--- a/examples/simple-rust/demo.rs
+++ b/examples/simple-rust/demo.rs
@@ -1,6 +1,6 @@
 use rusqlite::{ffi::sqlite3_auto_extension, Connection, Result};
 use sqlite_vec::sqlite3_vec_init;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 fn main() -> Result<()> {
     unsafe {


### PR DESCRIPTION
`zerocopy` [changed its API in 0.8](https://github.com/google/zerocopy/discussions/1680). The trait `AsBytes` had been renamed to `IntoBytes`.