### PR TITLE
fix linking with LDLIBS instead of CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ endif
 
 ifdef CONFIG_LINUX
 LOADABLE_EXTENSION=so
-CFLAGS += -lm
+LDLIBS += -lm
 endif
 
 ifdef CONFIG_WINDOWS
@@ -99,7 +99,8 @@ $(TARGET_LOADABLE): sqlite-vec.c sqlite-vec.h $(prefix)
 		-Ivendor/ \
 		-O3 \
 		$(CFLAGS) \
-		$< -o $@
+		$< -o $@ \
+		$(LDLIBS)
 
 $(TARGET_STATIC): sqlite-vec.c sqlite-vec.h $(prefix) $(OBJS_DIR)
 	$(CC) -Ivendor/ $(CFLAGS) -DSQLITE_CORE -DSQLITE_VEC_STATIC \


### PR DESCRIPTION
Related to #84 

The downloaded asset [sqlite-vec-0.1.6-loadable-linux-x86_64.tar.gz](https://github.com/asg017/sqlite-vec/releases/download/v0.1.6/sqlite-vec-0.1.6-loadable-linux-x86_64.tar.gz) has this output from ldd:

```
	linux-vdso.so.1 (0x00007ffff81f4000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x000079df72200000)
	/lib64/ld-linux-x86-64.so.2 (0x000079df724b5000)
```

The -lm flag needs to be moved to the end. After the change, the ldd output is:

```
	linux-vdso.so.1 (0x00007ffcfbf8d000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x0000706bf3b42000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x0000706bf3800000)
	/lib64/ld-linux-x86-64.so.2 (0x0000706bf3c56000)
```

Fixing the dependency on libm, and removing any `undefined symbol: sqrtf` errors when downloading the shared library file