### PR TITLE
Support android 16kb pages

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -134,7 +134,7 @@ jobs:
              AR=llvm-ar \
              RANLIB=llvm-ranlib \
              STRIP=llvm-strip \
-             CFLAGS="-Wl,-z,max-page-size=16384" \
+             LDFLAGS="-Wl,-z,max-page-size=16384" \
              loadable
       - uses: actions/upload-artifact@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -28,13 +28,12 @@ endif
 
 ifdef CONFIG_LINUX
 LOADABLE_EXTENSION=so
-CFLAGS += -lm
+LDLIBS += -lm
 endif
 
 ifdef CONFIG_WINDOWS
 LOADABLE_EXTENSION=dll
 endif
-
 
 ifdef python
 PYTHON=$(python)
@@ -99,11 +98,15 @@ $(TARGET_LOADABLE): sqlite-vec.c sqlite-vec.h $(prefix)
 		-Ivendor/ \
 		-O3 \
 		$(CFLAGS) \
-		$< -o $@
+		$< -o $@ \
+		$(LDFLAGS) $(LDLIBS)
 
 $(TARGET_STATIC): sqlite-vec.c sqlite-vec.h $(prefix) $(OBJS_DIR)
-	$(CC) -Ivendor/ $(CFLAGS) -DSQLITE_CORE -DSQLITE_VEC_STATIC \
-	-O3 -c  $< -o $(OBJS_DIR)/vec.o
+	$(CC) \
+	    -Ivendor/ \
+		$(CFLAGS) \
+		-DSQLITE_CORE -DSQLITE_VEC_STATIC \
+		-O3 -c  $< -o $(OBJS_DIR)/vec.o
 	$(AR) rcs $@ $(OBJS_DIR)/vec.o
 
 $(TARGET_STATIC_H): sqlite-vec.h $(prefix)
@@ -138,14 +141,14 @@ $(LIBS_DIR)/sqlite-vec.a: $(OBJS_DIR)/sqlite-vec.o $(LIBS_DIR)
 
 $(TARGET_CLI): sqlite-vec.h $(LIBS_DIR)/sqlite-vec.a $(LIBS_DIR)/shell.a $(LIBS_DIR)/sqlite3.a examples/sqlite3-cli/core_init.c $(prefix)
 	$(CC) -g3  \
-	-Ivendor/ -I./ \
-	-DSQLITE_CORE \
-	-DSQLITE_VEC_STATIC \
-	-DSQLITE_THREADSAFE=0 -DSQLITE_ENABLE_FTS4 \
-	-DSQLITE_ENABLE_STMT_SCANSTATUS -DSQLITE_ENABLE_BYTECODE_VTAB -DSQLITE_ENABLE_EXPLAIN_COMMENTS \
-	-DSQLITE_EXTRA_INIT=core_init \
-	$(CFLAGS) \
-	-ldl -lm \
+    	-Ivendor/ -I./ \
+    	-DSQLITE_CORE \
+    	-DSQLITE_VEC_STATIC \
+    	-DSQLITE_THREADSAFE=0 -DSQLITE_ENABLE_FTS4 \
+    	-DSQLITE_ENABLE_STMT_SCANSTATUS -DSQLITE_ENABLE_BYTECODE_VTAB -DSQLITE_ENABLE_EXPLAIN_COMMENTS \
+    	-DSQLITE_EXTRA_INIT=core_init \
+    	$(CFLAGS) \
+    	-ldl -lm \
 	examples/sqlite3-cli/core_init.c $(LIBS_DIR)/shell.a $(LIBS_DIR)/sqlite3.a $(LIBS_DIR)/sqlite-vec.a -o $@
 
 


### PR DESCRIPTION
Android now requires 16kb memory pages. [Users cannot submit app updates](https://github.com/OP-Engineering/op-sqlite/issues/366) until all libraries and binaries have been updated.

This in theory should enable 16kbs memory pages support but I'm not 100% familiar with the build process of sqlite-vec. It would also be important to get it out ASAP so I can update op-sqlite