### PR TITLE
Make the build scripts work on FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 COMMIT=$(shell git rev-parse HEAD)
 VERSION=$(shell cat VERSION)
 DATE=$(shell date +'%FT%TZ%z')
+VERSION_MAJOR=$(shell cut -d. -f1 VERSION)
+VERSION_MINOR=$(shell cut -d. -f2 VERSION)
+VERSION_PATCH=$(shell cut -d. -f3 VERSION | cut -d- -f1)
 
 INSTALL_LIB_DIR = /usr/local/lib
 INSTALL_INCLUDE_DIR = /usr/local/include
@@ -150,13 +153,17 @@ $(TARGET_CLI): sqlite-vec.h $(LIBS_DIR)/sqlite-vec.a $(LIBS_DIR)/shell.a $(LIBS_
 
 
 sqlite-vec.h: sqlite-vec.h.tmpl VERSION
-	VERSION=$(shell cat VERSION) \
+	VERSION=$(VERSION) \
 	DATE=$(shell date -r VERSION +'%FT%TZ%z') \
 	SOURCE=$(shell git log -n 1 --pretty=format:%H -- VERSION) \
-	VERSION_MAJOR=$$(echo $$VERSION | cut -d. -f1) \
-	VERSION_MINOR=$$(echo $$VERSION | cut -d. -f2) \
-	VERSION_PATCH=$$(echo $$VERSION | cut -d. -f3 | cut -d- -f1) \
+	VERSION_MAJOR=$(VERSION_MAJOR) \
+	VERSION_MINOR=$(VERSION_MINOR) \
+	VERSION_PATCH=$(VERSION_PATCH) \
 	envsubst < $< > $@
+	grep -Eq '^#define SQLITE_VEC_VERSION "[^"]+"' $@
+	grep -Eq '^#define SQLITE_VEC_VERSION_MAJOR [0-9]+' $@
+	grep -Eq '^#define SQLITE_VEC_VERSION_MINOR [0-9]+' $@
+	grep -Eq '^#define SQLITE_VEC_VERSION_PATCH [0-9]+' $@
 
 clean:
 	rm -rf dist
@@ -174,7 +181,7 @@ format: $(FORMAT_FILES)
 	clang-format -i $(FORMAT_FILES)
 	black tests/test-loadable.py
 
-lint: SHELL:=/bin/bash
+lint: SHELL:=$(shell command -v bash || echo /bin/bash)
 lint:
 	diff -u <(cat $(FORMAT_FILES)) <(clang-format $(FORMAT_FILES))
 

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail xtrace
 

--- a/scripts/vendor.sh
+++ b/scripts/vendor.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 mkdir -p vendor
 curl -o sqlite-amalgamation.zip https://www.sqlite.org/2024/sqlite-amalgamation-3450300.zip
 unzip sqlite-amalgamation.zip


### PR DESCRIPTION
## Summary

This PR makes the touched build scripts and header-generation path work on
FreeBSD without changing the overall release/build structure.

## What changed

- compute version macro parts directly in `Makefile`
- fail `sqlite-vec.h` generation immediately if the version macros are blank
- switch the touched shell scripts to `#!/usr/bin/env bash`

## Why this matters

On the validated FreeBSD host:

- the original `sqlite-vec.h` recipe could generate blank version macros
  because it depended on shell assignment ordering
- `/bin/bash` did not exist, even though bash was installed at
  `/usr/local/bin/bash`

The result was a FreeBSD source-build path that failed for reasons unrelated to
sqlite-vec itself.

## Validation

Validated on a real FreeBSD 15.0 amd64 host:

- `gmake clean && rm -f sqlite-vec.h && gmake sqlite-vec.h loadable`
- `sqlite3 :memory: ".load ./dist/vec0.so" "select vec_version();"`

## Known limits

- the Python test harness was not exercised on this host because the available
  Python 3.11 lacks the stdlib `_sqlite3` module
