### PR TITLE
Skip _vector_chunks rename for non-FLAT vec0 columns

### DIFF
--- a/sqlite-vec.c
+++ b/sqlite-vec.c
@@ -10435,9 +10435,13 @@ static int vec0Rename(sqlite3_vtab *pVtab, const char *zNew) {
 
   // Per-vector-column shadow tables
   for (int i = 0; i < p->numVectorColumns; i++) {
-    sqlite3_str_appendf(s,
-      "ALTER TABLE \"%w\".\"%w_vector_chunks%02d\" RENAME TO \"%w_vector_chunks%02d\";",
-      p->schemaName, p->tableName, i, zNew, i);
+    // Non-FLAT columns (rescore, IVF, DiskANN) don't create _vector_chunks
+    // (mirror the guard in vec0_init around VEC0_SHADOW_VECTOR_N_CREATE).
+    if (p->vector_columns[i].index_type == VEC0_INDEX_TYPE_FLAT) {
+      sqlite3_str_appendf(s,
+        "ALTER TABLE \"%w\".\"%w_vector_chunks%02d\" RENAME TO \"%w_vector_chunks%02d\";",
+        p->schemaName, p->tableName, i, zNew, i);
+    }
 
 #if SQLITE_VEC_ENABLE_RESCORE
     if (p->shadowRescoreChunksNames[i]) {

--- a/tests/test-rename.py
+++ b/tests/test-rename.py
@@ -162,6 +162,35 @@ def test_rename_with_metadata(db):
     assert _shadow_tables(db, "v") == []
 
 
+def test_rename_diskann(db):
+    """Rename should work on DiskANN-indexed tables (no _vector_chunks shadow)."""
+    db.execute("""
+        CREATE VIRTUAL TABLE v USING vec0(
+            a float[8] INDEXED BY diskann(neighbor_quantizer=binary)
+        )
+    """)
+    db.execute("insert into v(rowid, a) values (1, ?)", [_f32([0.1] * 8)])
+
+    # DiskANN columns use _vectors / _diskann_nodes / _diskann_buffer instead
+    # of _vector_chunks; the rename must skip the missing _vector_chunks ALTER.
+    before = _shadow_tables(db, "v")
+    assert "v_diskann_nodes00" in before
+    assert "v_vector_chunks00" not in before
+
+    db.execute("ALTER TABLE v RENAME TO v2")
+
+    rows = db.execute(
+        "select rowid from v2 where a match ? and k=10",
+        [_f32([0.1] * 8)],
+    ).fetchall()
+    assert rows[0][0] == 1
+
+    after = _shadow_tables(db, "v2")
+    assert "v2_diskann_nodes00" in after
+    assert "v2_vector_chunks00" not in after
+    assert _shadow_tables(db, "v") == []
+
+
 def test_rename_drop_after(db):
     """DROP TABLE should work on a renamed table."""
     db.execute("create virtual table v using vec0(a float[2], chunk_size=8)")


### PR DESCRIPTION
@asg017  I was using table renaming in order to force a flush in the DiskANN and this bug popped up with alter tables. I should note that don't know the sqlite-vec code very well and relied on Claude to identify this, so take with a grain of salt. 

vec0Rename emits an unconditional ALTER TABLE on `<name>_vector_chunks%02d` for every vector column, but non-FLAT columns (rescore, IVF, DiskANN) don't create that shadow table — so ALTER TABLE RENAME on a DiskANN-indexed (or rescore/IVF) vec0 table fails with `no such table` and leaves any cached prepared statements still referencing the old name.

Mirror the guard already used at create time in vec0_init around VEC0_SHADOW_VECTOR_N_CREATE: only rename `_vector_chunks` when the column's index_type is VEC0_INDEX_TYPE_FLAT.

Adds a regression test exercising rename on a DiskANN-indexed table.