### PR TITLE
Add release cached stmts command to flush DiskANN prepared statements without disconnect

### DIFF
--- a/sqlite-vec.c
+++ b/sqlite-vec.c
@@ -10271,6 +10271,33 @@ int vec0Update_Update(sqlite3_vtab *pVTab, int argc, sqlite3_value **argv) {
   return SQLITE_OK;
 }
 
+/*
+ * Index-type-agnostic vec0 control commands dispatched via the FTS5-style
+ * command column. Returns SQLITE_OK if handled, SQLITE_EMPTY otherwise.
+ *
+ * Recognized:
+ *   "release-cached-stmts"
+ *      Finalize this vec0 vtab's cached prepared statements
+ *      (stmtRowidsInsertRowid, stmtDiskannNodeRead, etc.) without renaming
+ *      or destroying the table. They are re-prepared lazily on next use.
+ *
+ *      Hosts embedding sqlite-vec sometimes need this. mozStorage in
+ *      Firefox, for example, calls sqlite3_close() on shutdown, which
+ *      fails (and asserts in debug builds) while any sqlite3_stmt* is
+ *      still live on the connection. vec0's cache would normally only be
+ *      finalized in xDisconnect, which runs *after* that close attempt.
+ *      Issuing this command before close lets the connection drain
+ *      cleanly. Cheaper than the rename-pair workaround because it
+ *      doesn't bump the schema cookie or write to shadow tables.
+ */
+static int vec0_handle_general_command(vec0_vtab *p, const char *cmd) {
+  if (strcmp(cmd, "release-cached-stmts") == 0) {
+    vec0_free_resources(p);
+    return SQLITE_OK;
+  }
+  return SQLITE_EMPTY;
+}
+
 static int vec0Update(sqlite3_vtab *pVTab, int argc, sqlite3_value **argv,
                       sqlite_int64 *pRowid) {
   // DELETE operation
@@ -10297,6 +10324,8 @@ static int vec0Update(sqlite3_vtab *pVTab, int argc, sqlite3_value **argv,
         if (cmdRc == SQLITE_EMPTY)
           cmdRc = diskann_handle_command(p, cmd);
 #endif
+        if (cmdRc == SQLITE_EMPTY)
+          cmdRc = vec0_handle_general_command(p, cmd);
         if (cmdRc == SQLITE_EMPTY) {
           vtab_set_error(pVTab, "unknown vec0 command: '%s'", cmd);
           return SQLITE_ERROR;

--- a/sqlite-vec.c
+++ b/sqlite-vec.c
@@ -10280,15 +10280,6 @@ int vec0Update_Update(sqlite3_vtab *pVTab, int argc, sqlite3_value **argv) {
  *      Finalize this vec0 vtab's cached prepared statements
  *      (stmtRowidsInsertRowid, stmtDiskannNodeRead, etc.) without renaming
  *      or destroying the table. They are re-prepared lazily on next use.
- *
- *      Hosts embedding sqlite-vec sometimes need this. mozStorage in
- *      Firefox, for example, calls sqlite3_close() on shutdown, which
- *      fails (and asserts in debug builds) while any sqlite3_stmt* is
- *      still live on the connection. vec0's cache would normally only be
- *      finalized in xDisconnect, which runs *after* that close attempt.
- *      Issuing this command before close lets the connection drain
- *      cleanly. Cheaper than the rename-pair workaround because it
- *      doesn't bump the schema cookie or write to shadow tables.
  */
 static int vec0_handle_general_command(vec0_vtab *p, const char *cmd) {
   if (strcmp(cmd, "release-cached-stmts") == 0) {

--- a/tests/test-release-cached-stmts.py
+++ b/tests/test-release-cached-stmts.py
@@ -1,0 +1,56 @@
+import sqlite3
+import pytest
+from helpers import _f32
+
+
+def test_release_cached_stmts_basic(db):
+    """The release-cached-stmts command should succeed and not affect data."""
+    db.execute("create virtual table v using vec0(a float[2], chunk_size=8)")
+    db.execute("insert into v(rowid, a) values (1, ?)", [_f32([0.1, 0.2])])
+    db.execute("insert into v(rowid, a) values (2, ?)", [_f32([0.3, 0.4])])
+
+    db.execute("insert into v(v) values ('release-cached-stmts')")
+
+    # Data should still be there and queryable; vec0's cached statements
+    # are re-prepared on demand.
+    rows = db.execute(
+        "select rowid from v where a match ? and k=10",
+        [_f32([0.1, 0.2])],
+    ).fetchall()
+    assert sorted(r[0] for r in rows) == [1, 2]
+
+
+def test_release_cached_stmts_before_any_use(db):
+    """Issuing the command before any inserts should be a no-op."""
+    db.execute("create virtual table v using vec0(a float[2], chunk_size=8)")
+    db.execute("insert into v(v) values ('release-cached-stmts')")
+    # Inserts and queries still work after.
+    db.execute("insert into v(rowid, a) values (1, ?)", [_f32([0.1, 0.2])])
+    rows = db.execute(
+        "select rowid from v where a match ? and k=10",
+        [_f32([0.1, 0.2])],
+    ).fetchall()
+    assert rows[0][0] == 1
+
+
+def test_release_cached_stmts_diskann(db):
+    """Works on DiskANN-indexed tables (the original motivating case)."""
+    db.execute("""
+        create virtual table v using vec0(
+            a float[8] indexed by diskann(neighbor_quantizer=binary)
+        )
+    """)
+    db.execute("insert into v(rowid, a) values (1, ?)", [_f32([0.1] * 8)])
+    db.execute("insert into v(v) values ('release-cached-stmts')")
+    rows = db.execute(
+        "select rowid from v where a match ? and k=10",
+        [_f32([0.1] * 8)],
+    ).fetchall()
+    assert rows[0][0] == 1
+
+
+def test_release_cached_stmts_unknown_subcommand(db):
+    """Unknown vec0 commands should still error as before."""
+    db.execute("create virtual table v using vec0(a float[2], chunk_size=8)")
+    with pytest.raises(sqlite3.OperationalError, match="unknown vec0 command"):
+        db.execute("insert into v(v) values ('not-a-real-command')")


### PR DESCRIPTION
@asg017  I'm seeing some [errors with Diskann](https://treeherder.mozilla.org/jobs?repo=try&revision=44f7fbe366036cd42d6ee419dd60c3befc9791c3&selectedTaskRun=GMyn6FnuTW-yd0NSQLWoJw.0) because there are some prepared statements pending when we are closing the connection. 

Is it advisable to have a flush command, or should I suppress these errors?

Attached is a flush implementation. As with my other patch, I heavily relied on Claude code since I don't know this codebase well.

  ## Summary
  Adds a new index-type-agnostic command dispatched via the existing FTS5-style
  command column on vec0:

  ```sql
  INSERT INTO vec_history(vec_history) VALUES('release-cached-stmts');

  It calls vec0_free_resources(p) directly, finalizing the cached
  sqlite3_stmt* handles vec0 keeps on the vtab (stmtRowidsInsertRowid,
  stmtDiskannNodeRead, stmtVectorsInsert, etc.). They're re-prepared lazily
  on the next operation.

  Why

  The vec0 cache is currently only finalized in xDisconnect / xDestroy /
  xRename. That's a problem for some embedders. Firefox's mozStorage, for
  example, calls sqlite3_close() on shutdown, which fails (and asserts in
  debug builds) while any sqlite3_stmt* is still alive on the connection.
  Workarounds today are either:
  - a no-op ALTER TABLE rename pair — bumps the schema cookie and writes to
  shadow tables, also invalidates host-side prepared-statement caches; or
  - close + reopen the connection — heavy hammer.


  Test plan
  tests/test-release-cached-stmts.py:
  - Command succeeds on a flat vec0 and data remains queryable after.
  - Command is a no-op when no statements are cached yet.
  - Command works on a DiskANN-indexed table (the original motivating case).
  - Unknown subcommands still produce the existing unknown vec0 command error.

