### PR TITLE
feat: Add Android/Termux support

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -1,0 +1,48 @@
+
+import { fileURLToPath } from "node:url";
+import { arch, platform } from "node:process";
+
+
+const BASE_PACKAGE_NAME = "sqlite-vec";
+const ENTRYPOINT_BASE_NAME = "vec0";
+const supportedPlatforms = [["darwin","x64"],["linux","x64"],["darwin","arm64"],["win32","x64"],["linux","arm64"],["android","arm64"]];
+
+const invalidPlatformErrorMessage = `Unsupported platform for ${BASE_PACKAGE_NAME}, on a ${platform}-${arch} machine. Supported platforms are (${supportedPlatforms
+  .map(([p, a]) => `${p}-${a}`)
+  .join(",")}). Consult the ${BASE_PACKAGE_NAME} NPM package README for details.`;
+
+const extensionNotFoundErrorMessage = packageName => `Loadble extension for ${BASE_PACKAGE_NAME} not found. Was the ${packageName} package installed?`;
+
+function validPlatform(platform, arch) {
+  return (
+    supportedPlatforms.find(([p, a]) => platform === p && arch === a) !== undefined
+  );
+}
+function extensionSuffix(platform) {
+  if (platform === "win32") return "dll";
+  if (platform === "darwin") return "dylib";
+  return "so";
+}
+function platformPackageName(platform, arch) {
+  let os = platform === "win32" ? "windows" : platform;
+  if (os === "android") os = "linux";
+  return `${BASE_PACKAGE_NAME}-${os}-${arch}`;
+}
+
+function getLoadablePath() {
+  if (!validPlatform(platform, arch)) {
+    throw new Error(
+      invalidPlatformErrorMessage
+    );
+  }
+  const packageName = platformPackageName(platform, arch);
+  const loadablePath = fileURLToPath(import.meta.resolve(packageName + "/" + ENTRYPOINT_BASE_NAME + "." + extensionSuffix(platform)));
+  return loadablePath;
+}
+
+function load(db) {
+  const p = getLoadablePath();
+  db.loadExtension(p.replace(/\.so$/, ''));
+}
+
+export {getLoadablePath, load};


### PR DESCRIPTION
## Summary
Adds `android-arm64` to the supported platforms list, enabling sqlite-vec to work on Termux (Android).

## Problem
On Termux (Android), `process.platform` returns `"android"` instead of `"linux"`, even though the device runs a Linux kernel. The current `supportedPlatforms` check rejects `android-arm64`, making sqlite-vec unusable on Termux.

The `sqlite-vec-linux-arm64` prebuilt binary works on Android, but `platformPackageName()` needs to map `android` → `linux` to resolve the correct package.

## Changes

### `index.mjs`

1. **Add android-arm64 to supportedPlatforms:**
```javascript
const supportedPlatforms = [
  ["darwin","x64"], ["linux","x64"], ["darwin","arm64"],
  ["win32","x64"], ["linux","arm64"], ["android","arm64"]
];
```

2. **Map android → linux in platformPackageName:**
```javascript
function platformPackageName(platform, arch) {
  let os = platform === "win32" ? "windows" : platform;
  if (os === "android") os = "linux";
  return `${BASE_PACKAGE_NAME}-${os}-${arch}`;
}
```

3. **Strip .so extension in load():**
```javascript
function load(db) {
  const p = getLoadablePath();
  db.loadExtension(p.replace(/\.so$/, ''));
}
```
(better-sqlite3's `loadExtension()` auto-appends `.so`, causing a double-extension error)

## Testing
Tested on Termux Android ARM64 (Node v26.3.1):
```
getLoadablePath: .../sqlite-vec-linux-arm64/vec0.so
vec_version: {"vec_version()":"v0.1.9"}
```

## Related
- Closes #68 (Android support tracking issue)
- Similar pattern to how `linuxmusl` platforms are handled

## Notes
- The `sqlite-vec-linux-arm64` binary compiles and runs natively on Android/Termux
- No new binary packages needed — reuses existing linux-arm64
- The `.so` extension stripping is consistent with how other SQLite extensions handle better-sqlite3