### PR TITLE
Apply KNN `distance` constraints in every index backend

### DIFF
--- a/sqlite-vec-rescore.c
+++ b/sqlite-vec-rescore.c
@@ -602,6 +602,36 @@ static int rescore_knn(vec0_vtab *p, vec0_cursor *pCur,
       }
     }
 
+    // Apply any `distance` constraints from the WHERE clause. This must happen
+    // on the rescored float distances (the coarse quantized distances from
+    // phase 1 are not comparable to a user-supplied threshold), and before the
+    // top-k truncation below, so that a constraint like `distance > x` can
+    // still yield k rows instead of dropping the head of the result set.
+    i64 cand_kept = 0;
+    for (i64 j = 0; j < cand_used; j++) {
+      if (!vec0_distance_constraints_satisfied(float_distances[j], idxStr, argc,
+                                               argv)) {
+        continue;
+      }
+      cand_rowids[cand_kept] = cand_rowids[j];
+      float_distances[cand_kept] = float_distances[j];
+      cand_kept++;
+    }
+    cand_used = cand_kept;
+
+    // Every candidate was filtered out: return an empty result set. Falling
+    // through would sqlite3_malloc(0), which returns NULL and would be
+    // misreported as SQLITE_NOMEM below.
+    if (cand_used == 0) {
+      knn_data->current_idx = 0;
+      knn_data->k = 0;
+      knn_data->rowids = NULL;
+      knn_data->distances = NULL;
+      knn_data->k_used = 0;
+      sqlite3_free(float_distances);
+      goto cleanup;
+    }
+
     i64 result_k = min(k, cand_used);
     i64 *out_rowids = sqlite3_malloc(result_k * sizeof(i64));
     f32 *out_distances = sqlite3_malloc(result_k * sizeof(f32));

--- a/sqlite-vec.c
+++ b/sqlite-vec.c
@@ -6009,6 +6009,53 @@ typedef enum {
   VEC0_DISTANCE_CONSTRAINT_LE = 'd',
 } vec0_distance_constraint_operator;
 
+/**
+ * @brief Test a single distance value against every distance constraint
+ *        encoded in idxStr.
+ *
+ * vec0BestIndex() sets aConstraintUsage[].omit = 1 on `distance` constraints,
+ * which promises SQLite that the vtab applies them itself. Every KNN
+ * implementation (FLAT, rescore, IVF, ...) MUST therefore route its candidate
+ * distances through this predicate, otherwise the WHERE clause is silently
+ * dropped from the query plan and never re-checked by SQLite.
+ *
+ * @param distance - candidate distance to test
+ * @param idxStr - the xBestIndex/xFilter idxStr
+ * @param argc, argv - xFilter arguments, parallel to the idxStr entries
+ * @returns 1 if the distance satisfies all constraints, 0 otherwise.
+ */
+static int vec0_distance_constraints_satisfied(f32 distance, const char *idxStr,
+                                               int argc,
+                                               sqlite3_value **argv) {
+  for (int i = 0; i < argc; i++) {
+    int idx = 1 + (i * 4);
+    if (idxStr[idx + 0] != VEC0_IDXSTR_KIND_KNN_DISTANCE_CONSTRAINT) {
+      continue;
+    }
+    // TODO casts f64 to f32, is that a problem?
+    f32 target = (f32)sqlite3_value_double(argv[i]);
+    switch ((vec0_distance_constraint_operator)idxStr[idx + 1]) {
+    case VEC0_DISTANCE_CONSTRAINT_GT:
+      if (!(distance > target))
+        return 0;
+      break;
+    case VEC0_DISTANCE_CONSTRAINT_GE:
+      if (!(distance >= target))
+        return 0;
+      break;
+    case VEC0_DISTANCE_CONSTRAINT_LT:
+      if (!(distance < target))
+        return 0;
+      break;
+    case VEC0_DISTANCE_CONSTRAINT_LE:
+      if (!(distance <= target))
+        return 0;
+      break;
+    }
+  }
+  return 1;
+}
+
 static int vec0BestIndex(sqlite3_vtab *pVTab, sqlite3_index_info *pIdxInfo) {
   vec0_vtab *p = (vec0_vtab *)pVTab;
   /**
@@ -7543,50 +7590,11 @@ int vec0Filter_knn_chunks_iter(vec0_vtab *p, sqlite3_stmt *stmtChunks,
     }
 
     if(hasDistanceConstraints) {
-      for(int i = 0; i < argc; i++) {
-        int idx = 1 + (i * 4);
-        char kind = idxStr[idx + 0];
-        // TODO casts f64 to f32, is that a problem?
-        f32 target = (f32) sqlite3_value_double(argv[i]);
-
-        if(kind != VEC0_IDXSTR_KIND_KNN_DISTANCE_CONSTRAINT)  {
-          continue;
-        }
-        vec0_distance_constraint_operator op = idxStr[idx + 1];
-
-        switch(op) {
-          case VEC0_DISTANCE_CONSTRAINT_GE: {
-            for(int i = 0; i < p->chunk_size;i++) {
-              if(bitmap_get(b, i) && !(chunk_distances[i] >= target)) {
-                bitmap_set(b, i, 0);
-              }
-            }
-            break;
-          }
-          case VEC0_DISTANCE_CONSTRAINT_GT: {
-            for(int i = 0; i < p->chunk_size;i++) {
-              if(bitmap_get(b, i) && !(chunk_distances[i] > target)) {
-                bitmap_set(b, i, 0);
-              }
-            }
-            break;
-          }
-          case VEC0_DISTANCE_CONSTRAINT_LE: {
-            for(int i = 0; i < p->chunk_size;i++) {
-              if(bitmap_get(b, i) && !(chunk_distances[i] <= target)) {
-                bitmap_set(b, i, 0);
-              }
-            }
-            break;
-          }
-          case VEC0_DISTANCE_CONSTRAINT_LT: {
-            for(int i = 0; i < p->chunk_size;i++) {
-              if(bitmap_get(b, i) && !(chunk_distances[i] < target)) {
-                bitmap_set(b, i, 0);
-              }
-            }
-            break;
-          }
+      for(int i = 0; i < p->chunk_size; i++) {
+        if(bitmap_get(b, i) &&
+           !vec0_distance_constraints_satisfied(chunk_distances[i], idxStr,
+                                                argc, argv)) {
+          bitmap_set(b, i, 0);
         }
       }
     }
@@ -7794,6 +7802,22 @@ static int vec0Filter_knn_diskann(
         resultRowids[sj] = tmpR;
       }
     }
+  }
+
+  // Apply any `distance` constraints from the WHERE clause. vec0BestIndex()
+  // omits these from the query plan, so SQLite will not re-check them.
+  {
+    int kept = 0;
+    for (int si = 0; si < resultCount; si++) {
+      if (!vec0_distance_constraints_satisfied(resultDistances[si], idxStr,
+                                               argc, argv)) {
+        continue;
+      }
+      resultRowids[kept] = resultRowids[si];
+      resultDistances[kept] = resultDistances[si];
+      kept++;
+    }
+    resultCount = kept;
   }
 
   knn_data->k = resultCount;
@@ -8070,6 +8094,22 @@ int vec0Filter_knn(vec0_cursor *pCur, vec0_vtab *p, int idxNum,
                        (int)vector_column_byte_size(*vector_column), k, knn_data);
     if (rc != SQLITE_OK) {
       goto cleanup;
+    }
+    // Apply any `distance` constraints from the WHERE clause. vec0BestIndex()
+    // omits these from the query plan, so SQLite will not re-check them.
+    {
+      i64 kept = 0;
+      for (i64 j = 0; j < knn_data->k_used; j++) {
+        if (!vec0_distance_constraints_satisfied(knn_data->distances[j], idxStr,
+                                                 argc, argv)) {
+          continue;
+        }
+        knn_data->rowids[kept] = knn_data->rowids[j];
+        knn_data->distances[kept] = knn_data->distances[j];
+        kept++;
+      }
+      knn_data->k = kept;
+      knn_data->k_used = kept;
     }
     pCur->knn_data = knn_data;
     pCur->query_plan = VEC0_QUERY_PLAN_KNN;

--- a/tests/test-knn-distance-constraints.py
+++ b/tests/test-knn-distance-constraints.py
@@ -1,3 +1,6 @@
+import random
+
+import pytest
 import sqlite3
 from helpers import exec
 
@@ -37,6 +40,148 @@ def test_normal(db, snapshot):
     assert exec(db, BASE_KNN + "AND distance > 7 AND distance <= 10", ["[1]", 5]) == snapshot()
     assert exec(db, BASE_KNN + "AND distance BETWEEN 7 AND 10", ["[1]", 5]) == snapshot()
     assert exec(db, BASE_KNN + "AND is_odd == TRUE AND distance BETWEEN 7 AND 10", ["[1]", 5]) == snapshot()
+
+
+# vec0BestIndex() sets `omit = 1` on distance constraints, which promises
+# SQLite that the vtab applies them itself. Every KNN backend must honor that
+# promise -- if one doesn't, the WHERE clause is silently dropped from the
+# query plan and rows that violate it are returned with no error at all.
+def _has_ivf():
+    db = sqlite3.connect(":memory:")
+    db.enable_load_extension(True)
+    db.load_extension("dist/vec0")
+    flags = db.execute("SELECT vec_debug()").fetchone()[0]
+    return "ivf" in flags.split("Build flags:")[-1].split()
+
+
+ANN_INDEX_DEFS = [
+    pytest.param("", id="flat"),
+    pytest.param(
+        "INDEXED BY rescore(quantizer=bit, oversample=16)", id="rescore-bit"
+    ),
+    pytest.param(
+        "INDEXED BY rescore(quantizer=int8, oversample=16)", id="rescore-int8"
+    ),
+    pytest.param(
+        "INDEXED BY diskann(neighbor_quantizer=int8)", id="diskann"
+    ),
+    pytest.param(
+        "INDEXED BY ivf(nlist=16, nprobe=8)",
+        id="ivf",
+        marks=pytest.mark.skipif(
+            not _has_ivf(),
+            reason="IVF not enabled (compile with -DSQLITE_VEC_EXPERIMENTAL_IVF_ENABLE=1)",
+        ),
+    ),
+]
+
+# Indexes that apply the constraint to their candidate pool *before* the top-k
+# truncation, and can therefore still return a full k rows. DiskANN and IVF
+# filter their final result set instead, so a lower-bound constraint there
+# legitimately yields fewer than k rows.
+INDEX_DEFS_FILLING_K = [p for p in ANN_INDEX_DEFS if p.id in ("flat", "rescore-bit", "rescore-int8")]
+
+DIMENSIONS = 8
+NROWS = 200
+
+
+def _seed(db, index_def):
+    db.execute(
+        f"CREATE VIRTUAL TABLE v USING vec0(embedding float[{DIMENSIONS}] {index_def})"
+    )
+    rng = random.Random(0)
+    rows = [
+        (i, "[" + ",".join(str(rng.random()) for _ in range(DIMENSIONS)) + "]")
+        for i in range(1, NROWS + 1)
+    ]
+    db.executemany("INSERT INTO v(rowid, embedding) VALUES (?, ?)", rows)
+    return rows
+
+
+@pytest.mark.parametrize("index_def", ANN_INDEX_DEFS)
+@pytest.mark.parametrize(
+    "op,predicate",
+    [
+        ("<=", lambda d, t: d <= t),
+        ("<", lambda d, t: d < t),
+        (">=", lambda d, t: d >= t),
+        (">", lambda d, t: d > t),
+    ],
+)
+def test_distance_constraint_is_honored_by_every_index(db, index_def, op, predicate):
+    """Regression test for #308.
+
+    Distance constraints were only implemented in the FLAT chunk scan. The
+    rescore path (added later, in #276) never read them back out of idxStr, so
+    `AND distance <= x` was silently ignored and every top-k row was returned.
+    """
+    rows = _seed(db, index_def)
+    query = rows[0][1]
+
+    unfiltered = db.execute(
+        "SELECT rowid, distance FROM v WHERE embedding MATCH ? AND k = 20",
+        (query,),
+    ).fetchall()
+    assert len(unfiltered) == 20
+
+    # Pick a threshold in the middle of the observed distance range, so that
+    # the constraint is neither a no-op nor filters everything out.
+    distances = sorted(row["distance"] for row in unfiltered)
+    threshold = distances[len(distances) // 2]
+
+    filtered = db.execute(
+        f"SELECT rowid, distance FROM v WHERE embedding MATCH ? AND k = 20 "
+        f"AND distance {op} ?",
+        (query, threshold),
+    ).fetchall()
+
+    violations = [row["distance"] for row in filtered if not predicate(row["distance"], threshold)]
+    assert violations == [], (
+        f"{len(violations)} row(s) violating `distance {op} {threshold}` were "
+        f"returned by index `{index_def or 'flat'}`"
+    )
+
+
+@pytest.mark.parametrize("index_def", ANN_INDEX_DEFS)
+def test_distance_constraint_filtering_everything_is_not_an_error(db, index_def):
+    """An impossible constraint must yield an empty result set, not an error.
+
+    On the rescore path this exercises the case where every rescored candidate
+    is filtered out: the result arrays are then zero-length, and a naive
+    sqlite3_malloc(0) returning NULL would be misreported as SQLITE_NOMEM.
+    """
+    rows = _seed(db, index_def)
+    result = db.execute(
+        "SELECT rowid FROM v WHERE embedding MATCH ? AND k = 10 AND distance < ?",
+        (rows[0][1], -1.0),
+    ).fetchall()
+    assert result == []
+
+
+@pytest.mark.parametrize("index_def", INDEX_DEFS_FILLING_K)
+def test_distance_constraint_lower_bound_still_fills_k(db, index_def):
+    """A `distance >` constraint must not shrink the result set.
+
+    The constraint has to be applied to the candidate pool *before* the top-k
+    truncation. Applying it afterwards would chop off the head of the sorted
+    results and return fewer than k rows.
+    """
+    rows = _seed(db, index_def)
+    query = rows[0][1]
+
+    unfiltered = db.execute(
+        "SELECT distance FROM v WHERE embedding MATCH ? AND k = 5", (query,)
+    ).fetchall()
+    # Exclude the 5 nearest neighbors; there are plenty of rows left beyond them.
+    threshold = max(row["distance"] for row in unfiltered)
+
+    filtered = db.execute(
+        "SELECT rowid, distance FROM v WHERE embedding MATCH ? AND k = 5 AND distance > ?",
+        (query, threshold),
+    ).fetchall()
+
+    assert len(filtered) == 5
+    assert all(row["distance"] > threshold for row in filtered)
 
 
 class Row:


### PR DESCRIPTION
Fixes #308. Diagnosis and reproduction numbers are in [this comment](https://github.com/asg017/sqlite-vec/issues/308#issuecomment-5177831448).

## The bug

`vec0BestIndex` accepts constraints on the `distance` column and unconditionally sets `omit = 1`:

```c
pIdxInfo->aConstraintUsage[i].argvIndex = argvIndex++;
pIdxInfo->aConstraintUsage[i].omit = 1;
```

That tells SQLite the vtab enforces the constraint itself, so SQLite drops the `WHERE` term from the query plan and never re-checks it. But the constraint was only ever read back out of `idxStr` in `vec0Filter_knn_chunks_iter` (FLAT). `rescore_knn`, `vec0Filter_knn_diskann` and `ivf_query_knn` never looked at it, so on those columns the predicate silently vanished and violating rows came back with no error.

It's a regression rather than a design gap: #166 landed the distance constraints on 2026-02-13, and the ANN backends (#276, #277, #278) merged on 2026-03-31 without wiring them up.

Measured on 200-300 random `float[8]` rows, `k = 20`, threshold at the median observed distance:

| backend | before | after |
|---|---|---|
| flat | 0 violating rows | 0 violating rows |
| rescore (bit) | **20 / 20 violating** | 0 |
| rescore (int8) | **20 / 20 violating** | 0 |
| diskann | **9-11 / 20 violating** | 0 |
| ivf | **9-11 / 20 violating** | 0 |

DiskANN is the one that bites in practice, since it's on by default (`SQLITE_VEC_ENABLE_DISKANN 1`) while IVF is opt-in. `AND distance < -1.0` also returned a full page of rows instead of none.

## The change

One helper, `vec0_distance_constraints_satisfied()`, becomes the single point of truth for the predicate, so `omit = 1` has exactly one place it can be honored and a future backend has an obvious thing to call:

- **FLAT** keeps its existing pre-filter semantics. Its four nested `switch` cases collapse into a single loop over the chunk bitmap that calls the helper — **net -44 lines**, and all 204 existing snapshots stay byte-identical.
- **rescore** filters the rescored float distances *before* the top-k truncation. The coarse quantized distances from phase 1 aren't comparable to a user-supplied threshold, so the filter can't be pushed down into the quantized scan; applying it after truncation would mean a lower-bound constraint chops off the head of the sorted results.
- **DiskANN / IVF** compact their final result sets.

It also fixes a latent bug on the rescore path that the new filter would otherwise have exposed: when every candidate is filtered out, `result_k` becomes 0, `sqlite3_malloc(0)` returns `NULL`, and the existing `if (!out_rowids || !out_distances)` check would have reported that as `SQLITE_NOMEM`.

## Caveat I'd rather state than hide

On DiskANN and IVF, a lower-bound constraint (`distance >`, `>=`) can return fewer than `k` rows, because the filter runs over the final result set rather than the candidate pool. Matching FLAT's semantics there means reaching into `diskann_search` / `ivf_query_knn` to widen the search, which felt like scope creep for a correctness fix. The tests encode this distinction explicitly (`INDEX_DEFS_FILLING_K`) rather than glossing over it — happy to go further if you'd prefer uniform semantics.

## Verification

New parametrized tests in `tests/test-knn-distance-constraints.py` cover all four operators across flat / rescore-bit / rescore-int8 / diskann, plus ivf behind a build-flag `skipif` mirroring `tests/conftest.py`.

- **17 of the new assertions fail on `main`** (22 with IVF enabled), all pass with this change
- Full suite: **262 passed, 0 failed**, 204 snapshots unchanged
- Clean under ASan + UBSan across all four backends and both empty-result edge cases

Conflict check: this shouldn't collide with #313 (IVF internals in `sqlite-vec-ivf.c`; I only touch the dispatch site in `sqlite-vec.c`) or #311 (DiskANN quantization, not filtering).

One unrelated snag for the record: `vendor/` isn't in the repo or a submodule, so `make loadable` and `make cli` don't work from a fresh clone — that's #291, and it's the only thing that stood between me and a one-command build.
