### PR TITLE
Fix OOB read on metadata IN filter path (size_t -> int)

### DIFF
--- a/sqlite-vec.c
+++ b/sqlite-vec.c
@@ -6987,7 +6987,7 @@ int vec0_metadata_filter_text(vec0_vtab * p, sqlite3_value * value, const void *
     }
 
     case VEC0_METADATA_OPERATOR_IN: {
-      size_t metadataInIdx = -1;
+      int metadataInIdx = -1;
       for(size_t i = 0; i < aMetadataIn->length; i++) {
         struct Vec0MetadataIn * metadataIn = &(((struct Vec0MetadataIn *) aMetadataIn->z)[i]);
         if(metadataIn->argv_idx == argv_idx) {

--- a/tests/test-metadata.py
+++ b/tests/test-metadata.py
@@ -624,3 +624,24 @@ def authorizer_deny_on(operation, x1, x2=None):
     return _auth
 
 
+def test_metadata_in_filter(db):
+    # Exercises the metadata `IN (...)` filter path (VEC0_METADATA_OPERATOR_IN).
+    # A not-found entry in that path indexed with a `size_t metadataInIdx = -1`
+    # (== SIZE_MAX) caused an out-of-bounds read; the `< 0` guard never fired
+    # for an unsigned type. The OOB is silent without a sanitizer, so this test
+    # asserts correct filtering and the ASan job turns the latent OOB fail-loud.
+    db.execute("create virtual table t using vec0(a float[2], label integer)")
+    db.executemany(
+        "insert into t(rowid, a, label) values (?, vec_f32(?), ?)",
+        [(i, f"[{i},{i}]", i % 3) for i in range(9)],
+    )
+    rows = db.execute(
+        "select rowid from t "
+        "where a match vec_f32('[0,0]') and k = 9 and label in (1, 2)"
+    ).fetchall()
+    found = sorted(r[0] for r in rows)
+    # rowids with label (i % 3) in {1, 2}: 1,2,4,5,7,8
+    assert found == [1, 2, 4, 5, 7, 8]
+    assert all(r % 3 != 0 for r in found)
+
+


### PR DESCRIPTION
## Summary

`vec0`'s metadata `IN (...)` filter path (`VEC0_METADATA_OPERATOR_IN` in `vec0_metadata_filter_text`) declares:

```c
size_t metadataInIdx = -1;
```

`size_t` is unsigned, so this wraps to `SIZE_MAX`. The subsequent not-found guard:

```c
if (metadataInIdx < 0) {
  rc = SQLITE_ERROR;
  goto done;
}
```

is dead code for an unsigned type — it can never fire. If the constraint lookup doesn't find a matching entry, execution falls through and indexes `aMetadataIn` with `SIZE_MAX`, an out-of-bounds read. The parallel `IN` handling in the same file (`vec0_filter`, a few hundred lines down) already declares this as `int` for the same reason — this is a case where the two `IN` code paths drifted apart.

## Fix

Change `metadataInIdx` to `int`, matching the already-correct sibling path. The guard now does what it always looked like it did.

## Testing

Added `test_metadata_in_filter` to `tests/test-metadata.py`, exercising a `label IN (...)` metadata filter with a full round-trip on a small `vec0` table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
